### PR TITLE
HSDO-1064 removed margin from content id

### DIFF
--- a/css/stanford_story_page.css
+++ b/css/stanford_story_page.css
@@ -22,6 +22,7 @@
   max-width: 1170px;
   margin: 0 auto;
 }
-.node-type-stanford-story-page #main-content {
+.node-type-stanford-story-page #main-content,
+.node-type-stanford-story-page #content {
   margin: 0;
 }

--- a/scss/stanford_story_page.scss
+++ b/scss/stanford_story_page.scss
@@ -29,7 +29,8 @@
     margin: 0 auto;
   }
 
-  #main-content {
+  #main-content,
+  #content {
     margin: 0;
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed margin from `#content` to address extra white space on Story Page

# Needed By (Date)
- End of sprint: 10/11

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Ensure that the white space on the righthand side of the pages is gone (result of `margin-left`)

# Affected Projects or Products
- H&S
- stanford_story_page

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/HSDO-1064

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)